### PR TITLE
Update AppendQueryToSheet.php

### DIFF
--- a/src/Jobs/AppendQueryToSheet.php
+++ b/src/Jobs/AppendQueryToSheet.php
@@ -7,13 +7,15 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\WithEvents;
+use Maatwebsite\Excel\Events\AfterChunk;
 use Maatwebsite\Excel\Files\TemporaryFile;
 use Maatwebsite\Excel\Jobs\Middleware\LocalizeJob;
 use Maatwebsite\Excel\Writer;
 
 class AppendQueryToSheet implements ShouldQueue
 {
-    use Queueable, Dispatchable, ProxyFailures, InteractsWithQueue;
+    use Queueable, Dispatchable, ProxyFailures, InteractsWithQueue, HasEventBus;
 
     /**
      * @var TemporaryFile
@@ -88,6 +90,11 @@ class AppendQueryToSheet implements ShouldQueue
     public function handle(Writer $writer)
     {
         (new LocalizeJob($this->sheetExport))->handle($this, function () use ($writer) {
+
+            if ($this->sheetExport instanceof WithEvents) {
+                $this->registerListeners($this->sheetExport->registerEvents());
+            }
+            
             $writer = $writer->reopen($this->temporaryFile, $this->writerType);
 
             $sheet = $writer->getSheetByIndex($this->sheetIndex);
@@ -97,6 +104,9 @@ class AppendQueryToSheet implements ShouldQueue
             $sheet->appendRows($query->get(), $this->sheetExport);
 
             $writer->write($this->sheetExport, $this->temporaryFile, $this->writerType);
+
+            $this->raise(new AfterChunk($sheet, $this->sheetExport, $this->page * $this->chunkSize));
+            $this->clearListeners();
         });
     }
 }


### PR DESCRIPTION
Add AfterChunk event for chunked exports

This PR allows the AfterChunk event to fire on exports.

1️⃣  Why should it be added? What are the benefits of this change?
With this, it is possible to

- showing the progress to the user
- estimate time for an export
 
2️⃣  Does it contain multiple, unrelated changes? Please separate the PRs out.
No

3️⃣  Does it include tests, if possible?
No

4️⃣  Any drawbacks? Possible breaking changes?
No

5️⃣  Mark the following tasks as done:

- [x] Checked the codebase to ensure that your feature doesn't already exist.
- [x] Take note of the contributing guidelines.
- [] Checked the pull requests to ensure that another person hasn't already submitted a fix.
- [] Added tests to ensure against regression.

6️⃣  Thanks for contributing! 🙌
